### PR TITLE
Per-Switch-user Discord profiles + on-device QR pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ Does not rely on anything other than your Switch and a mobile device for logging
 
 The rich presence is handled on the Switch itself, without the need for external tools on other computers.
 
+## Per-user Discord linking
+
+Each Nintendo Switch user profile can be linked to its own Discord account. The config app lists every Switch profile (plus a "Default (all profiles)" entry for any profile that isn't linked individually) along with its current link status, so you can give each person on the console their own Discord identity.
+
+When a game is running, the sysmodule looks up the currently-playing Switch user and pushes presence to **that** user's linked Discord account only. Presence is no longer mirrored to every linked account at once. Since the Switch only runs one application at a time, there is at most one active Discord session at a time, and the active Discord identity follows whichever Switch user is playing.
+
+If a profile has no link of its own, the Default link (if set) is used as a fallback. If neither exists, no presence is pushed for that user.
+
+In the config app:
+- Up/Down move between profiles.
+- A links a profile (or relinks one that is already linked).
+- X unlinks a linked profile.
+- Plus exits the app.
+
 > [!TIP]
 > Like this project? Own a Mac for developing? You might like [XRPC, Xcode Rich Presence done right](https://github.com/llsc12/XRPC).
 
@@ -17,15 +31,17 @@ Relies on tinfoil.io for game artworks. Uses Discord Social SDK endpoints for au
 
 Written in Embedded Swift!
 
+## Pairing
+
+Linking a profile is done entirely on-device. When you start a link, the Switch renders a QR code directly on its own screen (no web applet, no external page) pointing at the Switch's local web server, e.g. `http://<switch_ip>:45601`. Scan it with your phone, or type the URL printed underneath the QR code as a fallback.
+
+Your phone opens the local page, which kicks off the Discord OAuth2 (PKCE) flow. Once you approve, Discord redirects back to the Switch's local web server with the code and state, the Switch exchanges the code for tokens, fetches your Discord id and username, and saves the link for the profile you chose.
+
 ## Privacy
 
-The OAuth2 process happens through the Switch showing a web page at `https://static.llsc12.me/discord/qr?url=<discord_auth_shim>`.
+The OAuth2 process happens entirely between your Switch, your phone, and Discord. The QR code is generated and displayed locally on the Switch screen, so no external/static web page is involved in showing it.
 
-This page is a static page that renders a QR code for you to scan on your mobile device, leading to `https://static.llsc12.me/discord?ip=<switch_ip>&auth=<discord_oauth2_url>`.
-
-The Discord OAuth2 flow will redirect back to `https://static.llsc12.me/discord` again, with the code and state params from the Discord OAuth2 flow. The page will redirect again to the IP address of the Switch, which will be picked up by the Switch and you will be authenticated.
-
-All pages from this subdomain are static and hosted on GitHub Pages, you can examine them with inspect element to see exactly what they do.
+The QR code (and its fallback URL) point to the Switch's own local web server on your network (`http://<switch_ip>:45601`). The Discord OAuth2 flow redirects the code and state back to that local address, which the Switch picks up to complete authentication. Discord refresh tokens are stored on the SD card per linked profile.
 
 ## Credits
 

--- a/Sources/SwitchRPC/source/discord.cpp
+++ b/Sources/SwitchRPC/source/discord.cpp
@@ -4,8 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <string>
+#include <vector>
 #include <time.h>
-#include <set>
 #include <fstream>
 
 #include <switch.h>
@@ -18,61 +18,331 @@
 
 const char* clientId = "1249119754522857616";
 
-// discord authentication tokens
-std::string refreshToken = "";
-std::string authToken = "";
-// token for the rich presence session to refresh it every 15 minutes or delete it when the app is closed
-std::string sessionToken = "";
-time_t sessionTokenExpiry = 0; // we derive this ourselves by getting the time of the request we did to make the session + 20 minutes.
-// the time when the auth token will expire, so we can refresh it before it does
-time_t authTokenExpiry = 0;
+#define PROFILES_PATH     "sdmc:/config/switchrpc_profiles.json"
+#define LEGACY_TOKEN_PATH "sdmc:/config/switchrpc_token"
+#define SESSIONS_PATH     "sdmc:/config/switchrpc_sessions.json"
+#define LEGACY_SESSIONS_PATH "sdmc:/config/switchrpc_sessions"
 
+// Global link table. Pointers returned by resolveLink() remain valid until the
+// next loadLinks() call (which clears/rebuilds this vector). Callers must not
+// hold a pointer across a loadLinks() call.
+static std::vector<Link> g_links;
+// true when the links were loaded from the legacy switchrpc_token file (so
+// rotated tokens are written back to that file instead of profiles.json).
+static bool g_legacyMode = false;
 
-void getRefreshTokenFromFile() {
-    std::ifstream file("sdmc:/config/switchrpc_token");
-    if (!file.is_open()) {
-        writeToLog("[Discord] No refresh token found at sdmc:/config/switchrpc_token");
-        return; 
-    }
-    
-    std::string line;
-    if (std::getline(file, line)) {
-        refreshToken = line;
-        if (!refreshToken.empty() && refreshToken.back() == '\n') {
-            refreshToken.pop_back();
-        }
-        if (!refreshToken.empty() && refreshToken.back() == '\r') {
-            refreshToken.pop_back();
-        }
-        writeToLog("[Discord] Successfully read refresh token from file");
-    } else {
-        writeToLog("[Discord] Failed to read from sdmc:/config/switchrpc_token");
-    }
+// ------------------------------------------------------------------
+// small file helpers
+// ------------------------------------------------------------------
+
+static bool readFileContents(const char* path, std::string& out) {
+    std::ifstream file(path);
+    if (!file.is_open()) return false;
+    out.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     file.close();
+    return true;
 }
 
-void saveRefreshTokenToFile() {
-    // save the refresh token to a file on the sd card
-    std::ofstream file("sdmc:/config/switchrpc_token", std::ios::trunc);
-    if (!file.is_open()) { 
-        writeToLog("[Discord] Failed to open sdmc:/config/switchrpc_token for writing!");
-        return; 
+static void stripTrailingNewlines(std::string& s) {
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r')) {
+        s.pop_back();
     }
-    file << refreshToken;
-    file.close();
-    writeToLog("[Discord] Successfully saved new refresh token to file");
 }
 
-void saveSessionTokenToFile(const std::string& token) {
-    std::ofstream file("sdmc:/config/switchrpc_sessions", std::ios::app);
-    if (!file.is_open()) {
-        writeToLog("[Discord] Failed to open sdmc:/config/switchrpc_sessions for appending!");
+// Write data to path via a temp file + rename so a crash mid-write cannot leave
+// a half-written (corrupt) file. Falls back to a direct write if the rename
+// path fails, so data is never lost.
+static void writeFileAtomic(const char* path, const char* data) {
+    std::string tmp = std::string(path) + ".tmp";
+
+    {
+        std::ofstream out(tmp, std::ios::trunc);
+        if (!out.is_open()) {
+            std::ofstream direct(path, std::ios::trunc);
+            if (direct.is_open()) direct << data;
+            return;
+        }
+        out << data;
+        out.close();
+    }
+
+    // FAT/fsdev rename fails if the destination exists, so remove it first.
+    remove(path);
+    if (rename(tmp.c_str(), path) != 0) {
+        // rename failed: fall back to a direct write so the data isn't lost.
+        std::ofstream direct(path, std::ios::trunc);
+        if (direct.is_open()) direct << data;
+        remove(tmp.c_str());
+    }
+}
+
+// ------------------------------------------------------------------
+// switch_uid serialization
+// ------------------------------------------------------------------
+
+std::string accountUidToString(const AccountUid& uid) {
+    char buf[34];
+    snprintf(buf, sizeof(buf), "%016llx-%016llx",
+             (unsigned long long)uid.uid[0], (unsigned long long)uid.uid[1]);
+    return std::string(buf);
+}
+
+bool accountUidFromString(const std::string& s, AccountUid& out) {
+    out.uid[0] = 0;
+    out.uid[1] = 0;
+    size_t dash = s.find('-');
+    if (dash == std::string::npos) return false;
+    std::string a = s.substr(0, dash);
+    std::string b = s.substr(dash + 1);
+    if (a.empty() || b.empty()) return false;
+    out.uid[0] = (u64)strtoull(a.c_str(), NULL, 16);
+    out.uid[1] = (u64)strtoull(b.c_str(), NULL, 16);
+    return true;
+}
+
+static bool uidIsZero(const AccountUid& uid) {
+    return uid.uid[0] == 0 && uid.uid[1] == 0;
+}
+
+// ------------------------------------------------------------------
+// loadLinks / resolveLink
+// ------------------------------------------------------------------
+
+// helper: read a string member of a json object into dst (leaves dst unchanged
+// if missing). Copies into std::string so it is safe after json_object_put.
+static void getJsonString(json_object* obj, const char* key, std::string& dst) {
+    json_object* v;
+    if (json_object_object_get_ex(obj, key, &v)) {
+        const char* s = json_object_get_string(v);
+        if (s != NULL) dst.assign(s);
+    }
+}
+
+static void parseLinksFromJson(json_object* root) {
+    json_object* links_arr;
+    if (!json_object_object_get_ex(root, "links", &links_arr) ||
+        json_object_get_type(links_arr) != json_type_array) {
         return;
     }
-    file << token << std::endl;
-    file.close();
-    writeToLog("[Discord] Appended new session token to file");
+
+    int n = json_object_array_length(links_arr);
+    for (int i = 0; i < n; i++) {
+        json_object* doc = json_object_array_get_idx(links_arr, i);
+        if (doc == NULL) continue;
+
+        Link l;
+        getJsonString(doc, "switch_uid", l.switchUidStr);
+        getJsonString(doc, "discord_id", l.discordId);
+        getJsonString(doc, "discord_username", l.discordUsername);
+        getJsonString(doc, "refresh_token", l.refreshToken);
+
+        if (l.switchUidStr.empty()) {
+            // match the config app, which skips entries with no switch_uid rather
+            // than silently promoting them to the default/wildcard link.
+            continue;
+        }
+        accountUidFromString(l.switchUidStr, l.switchUid);
+
+        g_links.push_back(l);
+    }
 }
+
+std::vector<Link>& loadLinks() {
+    g_links.clear();
+    g_legacyMode = false;
+
+    // If profiles.json exists at all it is authoritative — never fall back to
+    // the legacy token (the config app migrates based on file existence, so the
+    // two sides must agree). A present-but-empty/unparseable file => zero links.
+    std::string contents;
+    bool profilesExist = readFileContents(PROFILES_PATH, contents);
+    if (profilesExist) {
+        if (!contents.empty()) {
+            json_object* root = json_tokener_parse(contents.c_str());
+            if (root != NULL) {
+                parseLinksFromJson(root);
+                json_object_put(root);
+                writeToLog("[Discord] Loaded %d link(s) from profiles.json", (int)g_links.size());
+            } else {
+                writeToLog("[Discord] profiles.json present but unparseable; treating as zero links.");
+            }
+        } else {
+            writeToLog("[Discord] profiles.json present but empty; treating as zero links.");
+        }
+        return g_links;
+    }
+
+    // No profiles.json: legacy fallback — single default/wildcard link backed by
+    // switchrpc_token (rotated tokens are written back to that file).
+    std::string legacy;
+    if (readFileContents(LEGACY_TOKEN_PATH, legacy)) {
+        stripTrailingNewlines(legacy);
+        if (!legacy.empty()) {
+            Link l;
+            l.switchUidStr = "0000000000000000-0000000000000000";
+            accountUidFromString(l.switchUidStr, l.switchUid);
+            l.refreshToken = legacy;
+            g_links.push_back(l);
+            g_legacyMode = true;
+            writeToLog("[Discord] Loaded legacy refresh token as a single default link.");
+            return g_links;
+        }
+    }
+
+    writeToLog("[Discord] No links found (no profiles.json and no legacy token).");
+    return g_links;
+}
+
+Link* resolveLink(const AccountUid& uid) {
+    Link* def = NULL;
+    for (size_t i = 0; i < g_links.size(); i++) {
+        Link& l = g_links[i];
+        if (l.switchUid.uid[0] == uid.uid[0] && l.switchUid.uid[1] == uid.uid[1]) {
+            return &l;
+        }
+        if (uidIsZero(l.switchUid)) {
+            def = &l;
+        }
+    }
+    return def;
+}
+
+// ------------------------------------------------------------------
+// persistence of rotated refresh tokens
+// ------------------------------------------------------------------
+
+void persistLinkRefreshToken(const Link& link) {
+    if (g_legacyMode) {
+        std::ofstream file(LEGACY_TOKEN_PATH, std::ios::trunc);
+        if (!file.is_open()) {
+            writeToLog("[Discord] Failed to open legacy token file for writing!");
+            return;
+        }
+        file << link.refreshToken;
+        file.close();
+        writeToLog("[Discord] Saved rotated refresh token to legacy file.");
+        return;
+    }
+
+    // read-modify-write profiles.json, preserving every other entry.
+    std::string contents;
+    readFileContents(PROFILES_PATH, contents);
+
+    json_object* root = contents.empty() ? NULL : json_tokener_parse(contents.c_str());
+    if (root == NULL) {
+        root = json_object_new_object();
+        json_object_object_add(root, "version", json_object_new_int(1));
+    }
+
+    json_object* links_arr;
+    if (!json_object_object_get_ex(root, "links", &links_arr) ||
+        json_object_get_type(links_arr) != json_type_array) {
+        links_arr = json_object_new_array();
+        json_object_object_add(root, "links", links_arr); // root takes ownership
+    }
+
+    bool found = false;
+    int n = json_object_array_length(links_arr);
+    for (int i = 0; i < n; i++) {
+        json_object* doc = json_object_array_get_idx(links_arr, i);
+        if (doc == NULL) continue;
+        json_object* juid;
+        if (json_object_object_get_ex(doc, "switch_uid", &juid)) {
+            const char* s = json_object_get_string(juid);
+            if (s != NULL && link.switchUidStr == s) {
+                // object_add replaces existing key, freeing the old value.
+                json_object_object_add(doc, "refresh_token",
+                                       json_object_new_string(link.refreshToken.c_str()));
+                found = true;
+                break;
+            }
+        }
+    }
+
+    if (!found) {
+        // The entry is gone (e.g. the config app unlinked this profile while a
+        // session was active). Do NOT resurrect it — skip persistence.
+        writeToLog("[Discord] Link %s not in profiles.json; not persisting (it may have been unlinked).",
+                   link.switchUidStr.c_str());
+        json_object_put(root);
+        return;
+    }
+
+    writeFileAtomic(PROFILES_PATH, json_object_to_json_string(root));
+    writeToLog("[Discord] Persisted rotated refresh token to profiles.json for %s",
+               link.switchUidStr.c_str());
+
+    json_object_put(root);
+}
+
+// ------------------------------------------------------------------
+// sessions bookkeeping (switchrpc_sessions.json)
+// ------------------------------------------------------------------
+
+// Upsert (or, when token is empty, remove) the session entry for a given uid in
+// switchrpc_sessions.json. Keeps at most one entry per switch_uid so the file
+// stays bounded (the Switch runs one app at a time). Rebuilds the array rather
+// than relying on json_object_array_del_idx for older json-c compatibility.
+static void upsertSessionEntry(const std::string& uidStr, const std::string& token) {
+    std::string contents;
+    readFileContents(SESSIONS_PATH, contents);
+    json_object* oldRoot = contents.empty() ? NULL : json_tokener_parse(contents.c_str());
+
+    json_object* newRoot = json_object_new_object();
+    json_object* newArr = json_object_new_array();
+    json_object_object_add(newRoot, "sessions", newArr); // newRoot takes ownership
+
+    if (oldRoot != NULL) {
+        json_object* sessions;
+        if (json_object_object_get_ex(oldRoot, "sessions", &sessions) &&
+            json_object_get_type(sessions) == json_type_array) {
+            int n = json_object_array_length(sessions);
+            for (int i = 0; i < n; i++) {
+                json_object* doc = json_object_array_get_idx(sessions, i);
+                if (doc == NULL) continue;
+                json_object* juid;
+                json_object* jtok;
+                if (!json_object_object_get_ex(doc, "switch_uid", &juid) ||
+                    !json_object_object_get_ex(doc, "token", &jtok)) continue;
+                const char* u = json_object_get_string(juid);
+                const char* t = json_object_get_string(jtok);
+                std::string us = (u != NULL) ? u : "";
+                std::string ts = (t != NULL) ? t : "";
+                if (us == uidStr) continue;       // drop the old entry for this uid
+                if (us.empty() || ts.empty()) continue;
+                json_object* e = json_object_new_object();
+                json_object_object_add(e, "switch_uid", json_object_new_string(us.c_str()));
+                json_object_object_add(e, "token", json_object_new_string(ts.c_str()));
+                json_object_array_add(newArr, e); // newArr takes ownership
+            }
+        }
+        json_object_put(oldRoot);
+    }
+
+    // add the updated entry unless this is a removal (empty token)
+    if (!token.empty()) {
+        json_object* e = json_object_new_object();
+        json_object_object_add(e, "switch_uid", json_object_new_string(uidStr.c_str()));
+        json_object_object_add(e, "token", json_object_new_string(token.c_str()));
+        json_object_array_add(newArr, e); // newArr takes ownership
+    }
+
+    if (json_object_array_length(newArr) == 0) {
+        // nothing left to track: drop the file entirely
+        remove(SESSIONS_PATH);
+        json_object_put(newRoot);
+        return;
+    }
+
+    writeFileAtomic(SESSIONS_PATH, json_object_to_json_string(newRoot));
+    writeToLog("[Discord] Updated sessions.json for %s", uidStr.c_str());
+
+    json_object_put(newRoot);
+}
+
+// ------------------------------------------------------------------
+// curl helpers (unchanged behaviour)
+// ------------------------------------------------------------------
 
 int curlDebugCallback(CURL *handle, curl_infotype type, char *data, size_t size, void *userp) {
     (void)handle; // Unused
@@ -83,7 +353,7 @@ int curlDebugCallback(CURL *handle, curl_infotype type, char *data, size_t size,
         case CURLINFO_TEXT:         type_str = "Info"; break;
         case CURLINFO_HEADER_IN:    type_str = "Recv Header"; break;
         case CURLINFO_HEADER_OUT:   type_str = "Send Header"; break;
-        default: return 0; 
+        default: return 0;
     }
 
     std::string text(data, size);
@@ -152,7 +422,7 @@ bool sendRequest(const char* url, const char* method, struct curl_slist* headers
         struct curl_slist *dns_cache = NULL;
         dns_cache = curl_slist_append(dns_cache, "discord.com:443:162.159.138.232");
         dns_cache = curl_slist_append(dns_cache, "discord.com:443:162.159.135.232");
-        
+
         dns_cache = curl_slist_append(dns_cache, "gaming-sdk.com:443:104.18.41.99");
         dns_cache = curl_slist_append(dns_cache, "gaming-sdk.com:443:172.64.146.157");
         curl_easy_setopt(curl, CURLOPT_RESOLVE, dns_cache);
@@ -163,12 +433,12 @@ bool sendRequest(const char* url, const char* method, struct curl_slist* headers
             size_t total_size = size * nmemb;
             if (userdata != NULL) {
                 std::string* resp = static_cast<std::string*>(userdata);
-                resp->append(ptr, total_size); 
+                resp->append(ptr, total_size);
             }
             return total_size;
         });
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, response); 
-        
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, response);
+
         CURLcode res = curl_easy_perform(curl);
         if(res != CURLE_OK) {
             writeToLog("[Discord] cURL request failed: %s", curl_easy_strerror(res));
@@ -185,9 +455,9 @@ bool sendRequest(const char* url, const char* method, struct curl_slist* headers
         long http_code = 0;
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
         bool success = (http_code >= 200 && http_code < 300);
-        
+
         curl_slist_free_all(reqHeaders);
-        curl_slist_free_all(headers); 
+        curl_slist_free_all(headers);
         curl_slist_free_all(dns_cache);
         curl_easy_cleanup(curl);
         return success;
@@ -198,27 +468,29 @@ bool sendRequest(const char* url, const char* method, struct curl_slist* headers
     }
 }
 
-bool refreshAuthTokenIfNeeded() {
-    // check that we have a refresh token, if not, we can't do anything
-    getRefreshTokenFromFile();
-    if (refreshToken.empty()) { 
-        writeToLog("[Discord] Cannot refresh: Refresh token is empty");
-        return false; 
+// ------------------------------------------------------------------
+// per-link auth
+// ------------------------------------------------------------------
+
+bool refreshAuthTokenIfNeeded(Link& link) {
+    if (link.refreshToken.empty()) {
+        writeToLog("[Discord] Cannot refresh: refresh token is empty for %s", link.switchUidStr.c_str());
+        return false;
     }
 
-    // check if the auth token is expired or will expire in the next 5 minutes
-    if (time(NULL) < authTokenExpiry - 300) { 
-        writeToLog("[Discord] Auth token is still valid.");
+    // still valid (with a 5 minute safety margin)?
+    if (!link.authToken.empty() && time(NULL) < link.authTokenExpiry - 300) {
+        writeToLog("[Discord] Auth token still valid for %s.", link.switchUidStr.c_str());
         return true;
     }
 
-    writeToLog("[Discord] Auth token expired or expiring soon. Refreshing...");
+    writeToLog("[Discord] Refreshing auth token for %s...", link.switchUidStr.c_str());
 
     const char* url = "https://gaming-sdk.com/api/v9/oauth2/token";
     const char* method = "POST";
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Content-Type: application/x-www-form-urlencoded; charset=utf-8");
-    std::string bodyStr = "grant_type=refresh_token&refresh_token=" + refreshToken + "&client_id=" + clientId;
+    std::string bodyStr = "grant_type=refresh_token&refresh_token=" + link.refreshToken + "&client_id=" + clientId;
 
     std::string response = "";
     bool success = sendRequest(url, method, headers, bodyStr.c_str(), &response);
@@ -229,99 +501,151 @@ bool refreshAuthTokenIfNeeded() {
     }
 
     json_object* json_response = json_tokener_parse(response.c_str());
-    if (json_response == NULL) { 
+    if (json_response == NULL) {
         writeToLog("[Discord] Failed to parse JSON response from token refresh!");
-        return false; 
-    }
-    
-    json_object* json_auth_token;
-    json_object* json_refresh_token;
-    json_object* json_expires_in;
-    
-    if (json_object_object_get_ex(json_response, "access_token", &json_auth_token)) {
-        authToken = json_object_get_string(json_auth_token);
-        writeToLog("[Discord] Successfully extracted new access_token");
-    }
-    if (json_object_object_get_ex(json_response, "refresh_token", &json_refresh_token)) {
-        refreshToken = json_object_get_string(json_refresh_token);
-        writeToLog("[Discord] Successfully extracted new refresh_token");
-    }
-    if (json_object_object_get_ex(json_response, "expires_in", &json_expires_in)) {
-        authTokenExpiry = time(NULL) + json_object_get_int(json_expires_in);
-    }
-
-    json_object_put(json_response); // Frees the parsed json object
-
-    // save the new refresh token to the sd card
-    saveRefreshTokenToFile();
-    return true;
-}
-
-bool authenticatedRequest(const char* url, const char* method, struct curl_slist* headers, const char* body, std::string* response) {
-    refreshAuthTokenIfNeeded();
-    
-    if (authToken.empty()) {
-        writeToLog("[Discord] WARNING: Attempted authenticated request but authToken is empty!");
         return false;
     }
 
-    std::string authHeader = "Authorization: Bearer " + authToken;
+    bool rotated = false;
+    json_object* json_auth_token;
+    json_object* json_refresh_token;
+    json_object* json_expires_in;
+
+    if (json_object_object_get_ex(json_response, "access_token", &json_auth_token)) {
+        const char* s = json_object_get_string(json_auth_token);
+        if (s != NULL) link.authToken.assign(s);
+        writeToLog("[Discord] Extracted new access_token for %s", link.switchUidStr.c_str());
+    }
+    if (json_object_object_get_ex(json_response, "refresh_token", &json_refresh_token)) {
+        const char* s = json_object_get_string(json_refresh_token);
+        if (s != NULL) {
+            link.refreshToken.assign(s);
+            rotated = true;
+        }
+    }
+    if (json_object_object_get_ex(json_response, "expires_in", &json_expires_in)) {
+        link.authTokenExpiry = time(NULL) + json_object_get_int(json_expires_in);
+    }
+
+    json_object_put(json_response);
+
+    if (rotated) {
+        persistLinkRefreshToken(link);
+    }
+
+    return !link.authToken.empty();
+}
+
+bool authenticatedRequest(Link& link, const char* url, const char* method, struct curl_slist* headers, const char* body, std::string* response) {
+    refreshAuthTokenIfNeeded(link);
+
+    if (link.authToken.empty()) {
+        writeToLog("[Discord] WARNING: authenticated request but authToken empty for %s!", link.switchUidStr.c_str());
+        curl_slist_free_all(headers); // sendRequest would have owned/freed these
+        return false;
+    }
+
+    std::string authHeader = "Authorization: Bearer " + link.authToken;
     struct curl_slist* authHeaders = curl_slist_append(headers, authHeader.c_str());
     return sendRequest(url, method, authHeaders, body, response);
 }
 
+// ------------------------------------------------------------------
+// headless session management (per-link)
+// ------------------------------------------------------------------
+
 void discordCleanupStaleSessions() {
-    std::ifstream file("sdmc:/config/switchrpc_sessions");
-    if (!file.is_open()) {
-        writeToLog("[Discord] No stale sessions file found. Skipping cleanup.");
+    // legacy plaintext sessions file -> delete best-effort + log
+    {
+        std::ifstream legacy(LEGACY_SESSIONS_PATH);
+        if (legacy.is_open()) {
+            legacy.close();
+            writeToLog("[Discord] Found legacy plaintext sessions file; deleting best-effort.");
+            if (remove(LEGACY_SESSIONS_PATH) != 0) {
+                writeToLog("[Discord] Failed to remove legacy plaintext sessions file.");
+            }
+        }
+    }
+
+    std::string contents;
+    if (!readFileContents(SESSIONS_PATH, contents)) {
+        writeToLog("[Discord] No sessions.json found. Skipping cleanup.");
+        return;
+    }
+    if (contents.empty()) {
+        remove(SESSIONS_PATH);
         return;
     }
 
-    writeToLog("[Discord] Found switchrpc_sessions file, cleaning up stale sessions...");
-    
-    std::set<std::string> uniqueTokens;
-    std::string line;
-    
-    while (std::getline(file, line)) {
-        if (!line.empty() && line.back() == '\r') {
-            line.pop_back();
-        }
-        if (!line.empty()) {
-            uniqueTokens.insert(line);
+    json_object* root = json_tokener_parse(contents.c_str());
+    if (root == NULL) {
+        writeToLog("[Discord] sessions.json not valid JSON; deleting best-effort.");
+        remove(SESSIONS_PATH);
+        return;
+    }
+
+    json_object* sessions;
+    if (json_object_object_get_ex(root, "sessions", &sessions) &&
+        json_object_get_type(sessions) == json_type_array) {
+
+        int n = json_object_array_length(sessions);
+        writeToLog("[Discord] Cleaning up %d recorded session(s)...", n);
+
+        for (int i = 0; i < n; i++) {
+            json_object* doc = json_object_array_get_idx(sessions, i);
+            if (doc == NULL) continue;
+
+            json_object* juid;
+            json_object* jtok;
+            if (!json_object_object_get_ex(doc, "switch_uid", &juid) ||
+                !json_object_object_get_ex(doc, "token", &jtok)) {
+                writeToLog("[Discord] Skipping malformed session entry.");
+                continue;
+            }
+
+            // copy out of json before any json_object_put
+            const char* uidRaw = json_object_get_string(juid);
+            const char* tokRaw = json_object_get_string(jtok);
+            std::string uidStr = (uidRaw != NULL) ? uidRaw : "";
+            std::string token  = (tokRaw != NULL) ? tokRaw : "";
+            if (token.empty()) continue;
+
+            AccountUid uid {};
+            accountUidFromString(uidStr, uid);
+            Link* link = resolveLink(uid);
+            if (link == NULL) {
+                writeToLog("[Discord] No link for session uid %s; skipping (cannot delete).", uidStr.c_str());
+                continue;
+            }
+
+            json_object* json_body = json_object_new_object();
+            json_object_object_add(json_body, "token", json_object_new_string(token.c_str()));
+            const char* body = json_object_get_string(json_body);
+
+            struct curl_slist* headers = NULL;
+            headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
+
+            writeToLog("[Discord] Deleting stale session for uid %s...", uidStr.c_str());
+            authenticatedRequest(*link, "https://discord.com/api/v9/users/@me/headless-sessions/delete",
+                                 "POST", headers, body, NULL);
+
+            json_object_put(json_body);
         }
     }
-    file.close();
 
-    if (!sessionToken.empty() && uniqueTokens.count(sessionToken) > 0) {
-        if (time(NULL) < sessionTokenExpiry) {
-            uniqueTokens.erase(sessionToken);
-        }
-    }
-    
-    for (const std::string& token : uniqueTokens) {
-        json_object* json_body = json_object_new_object();
-        json_object_object_add(json_body, "token", json_object_new_string(token.c_str()));
-        const char* body = json_object_get_string(json_body);
+    json_object_put(root);
 
-        struct curl_slist* headers = NULL;
-        headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
-
-        writeToLog("[Discord] Deleting stale headless session...");
-        authenticatedRequest("https://discord.com/api/v9/users/@me/headless-sessions/delete", "POST", headers, body, NULL);
-
-        json_object_put(json_body);
-    }
-    
-    if (remove("sdmc:/config/switchrpc_sessions") == 0) {
-        writeToLog("[Discord] Successfully removed sessions file.");
+    if (remove(SESSIONS_PATH) == 0) {
+        writeToLog("[Discord] Cleared sessions.json.");
     } else {
-        writeToLog("[Discord] Failed to remove sessions file after cleanup.");
+        writeToLog("[Discord] Failed to remove sessions.json after cleanup.");
     }
 }
 
-void discordCreateHeadlessSession(u64 titleId, std::string titleName, const bool includeToken) {
-    writeToLog("[Discord] Creating/Updating session for TID: %016llX (%s)", (unsigned long long)titleId, titleName.c_str());
-    
+bool discordCreateHeadlessSession(Link& link, u64 titleId, std::string titleName, const bool includeToken) {
+    writeToLog("[Discord] Creating/Updating session for TID: %016llX (%s) on %s",
+               (unsigned long long)titleId, titleName.c_str(), link.switchUidStr.c_str());
+
     // tries to fetch eshop icon, else falls back to tinfoil media icon
     std::string iconUrl;
     if (!fetchEshopIconUrl(titleId, iconUrl)) {
@@ -336,90 +660,102 @@ void discordCreateHeadlessSession(u64 titleId, std::string titleName, const bool
     json_object* json_activities = json_object_new_array();
     json_object* json_activity = json_object_new_object();
     json_object_object_add(json_activity, "type", json_object_new_string("0"));
-    json_object_object_add(json_activity, "flags", json_object_new_string("0"));  
+    json_object_object_add(json_activity, "flags", json_object_new_string("0"));
     json_object_object_add(json_activity, "application_id", json_object_new_string(clientId));
     json_object_object_add(json_activity, "platform", json_object_new_string("desktop"));
     json_object_object_add(json_activity, "name", json_object_new_string(titleName.c_str()));
     json_object_object_add(json_activity, "state", json_object_new_string("Nintendo Switch"));
-    
+
     json_object* json_assets = json_object_new_object();
     json_object_object_add(json_assets, "large_image", json_object_new_string(iconUrl.c_str()));
     json_object_object_add(json_activity, "assets", json_assets);
-    
+
     json_object_array_add(json_activities, json_activity);
     json_object_object_add(json_body, "activities", json_activities);
-    
-    if (includeToken && !sessionToken.empty()) {
+
+    if (includeToken && !link.sessionToken.empty()) {
         writeToLog("[Discord] Including session token in request.");
-        json_object_object_add(json_body, "token", json_object_new_string(sessionToken.c_str()));
+        json_object_object_add(json_body, "token", json_object_new_string(link.sessionToken.c_str()));
     }
-    
+
     const char* body = json_object_get_string(json_body);
 
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
 
     std::string response;
-    bool success = authenticatedRequest("https://discord.com/api/v9/users/@me/headless-sessions", "POST", headers, body, &response);
+    bool success = authenticatedRequest(link, "https://discord.com/api/v9/users/@me/headless-sessions", "POST", headers, body, &response);
     if (!success) {
         writeToLog("[Discord] Failed to create/update headless session!");
         json_object_put(json_body);
 
-        // if the attempt happened with an existing session token, try again without it in case the token was the issue
+        // if the attempt included an existing session token, retry once without
+        // it in case the (possibly stale) token was the problem.
         if (includeToken) {
             writeToLog("[Discord] Retrying headless session creation without session token...");
-            return discordCreateHeadlessSession(titleId, titleName, false);
+            return discordCreateHeadlessSession(link, titleId, titleName, false);
         }
+        return false;
     }
 
     json_object_put(json_body);
 
     json_object* json_response = json_tokener_parse(response.c_str());
-    if (json_response == NULL) { 
+    if (json_response == NULL) {
         writeToLog("[Discord] Failed to parse headless session response JSON!");
-        return; 
+        return false;
     }
-    
+
+    bool stored = false;
     json_object* json_session_token;
     if (json_object_object_get_ex(json_response, "token", &json_session_token)) {
-        std::string newToken = json_object_get_string(json_session_token);
-        if (newToken != sessionToken) {
-            sessionToken = newToken;
-            saveSessionTokenToFile(sessionToken);
+        const char* s = json_object_get_string(json_session_token);
+        std::string newToken = (s != NULL) ? s : "";
+
+        if (!newToken.empty() && newToken != link.sessionToken) {
+            // a new session token: upsert it (keyed by this link's uid, one entry
+            // per uid) so stale-cleanup can delete it later with the right creds.
+            upsertSessionEntry(link.switchUidStr, newToken);
         }
 
-        sessionToken = newToken;
-        sessionTokenExpiry = time(NULL) + 900; // 15 mins to be safe.
-        
-        writeToLog("[Discord] Successfully extracted session token.");
+        if (!newToken.empty()) {
+            link.sessionToken = newToken;
+            link.sessionTokenExpiry = time(NULL) + 900; // 15 mins to be safe.
+            stored = true;
+            writeToLog("[Discord] Stored session token for %s.", link.switchUidStr.c_str());
+        }
     } else {
         writeToLog("[Discord] Headless session response did NOT contain a session token. That shouldn't happen if the session was created successfully and discord returned 200.");
     }
 
     json_object_put(json_response);
+    return stored;
 }
 
-void discordDeleteHeadlessSession() {
-    writeToLog("[Discord] Deleting headless session...");
-    
-    if (sessionToken.empty()) { 
+void discordDeleteHeadlessSession(Link& link) {
+    writeToLog("[Discord] Deleting headless session for %s...", link.switchUidStr.c_str());
+
+    if (link.sessionToken.empty()) {
         writeToLog("[Discord] No active session token to delete.");
-        return; 
+        return;
     }
 
     json_object* json_body = json_object_new_object();
-    json_object_object_add(json_body, "token", json_object_new_string(sessionToken.c_str()));
+    json_object_object_add(json_body, "token", json_object_new_string(link.sessionToken.c_str()));
     const char* body = json_object_get_string(json_body);
 
     struct curl_slist* headers = NULL;
     headers = curl_slist_append(headers, "Content-Type: application/json; charset=utf-8");
 
-    authenticatedRequest("https://discord.com/api/v9/users/@me/headless-sessions/delete", "POST", headers, body, NULL);
+    authenticatedRequest(link, "https://discord.com/api/v9/users/@me/headless-sessions/delete", "POST", headers, body, NULL);
 
     json_object_put(json_body);
-    
+
+    // drop this uid's entry from sessions.json (it is deleted server-side now).
+    upsertSessionEntry(link.switchUidStr, "");
+
     // Clear the token so we don't try to use it again
-    sessionToken = "";
-    sessionTokenExpiry = 0;
-    writeToLog("[Discord] Session deleted successfully.");
+    link.sessionToken = "";
+    link.sessionTokenExpiry = 0;
+    writeToLog("[Discord] Session deleted.");
 }

--- a/Sources/SwitchRPC/source/discord.hpp
+++ b/Sources/SwitchRPC/source/discord.hpp
@@ -3,27 +3,97 @@
 #pragma once
 
 #include <switch.h>
+#include <string>
+#include <vector>
+#include <time.h>
+
+// ------------------------------------------------------------------
+// Per-Switch-user link model
+// ------------------------------------------------------------------
+
+// A Link connects a single Switch user profile to a single Discord account.
+// Each link carries its OWN OAuth credentials and (at runtime) its OWN
+// active headless-session token.
+struct Link {
+    AccountUid switchUid {};              // all-zero == DEFAULT/wildcard link
+    std::string switchUidStr;             // "%016llx-%016llx"
+    std::string discordId;               // display only / sessions bookkeeping
+    std::string discordUsername;         // display only
+    std::string refreshToken;            // ROTATES on each refresh
+    std::string authToken;               // bearer token (in-memory only)
+    time_t authTokenExpiry = 0;          // when authToken expires (epoch secs)
+
+    // runtime-only headless session state for this link
+    std::string sessionToken;            // active rich-presence session token
+    time_t sessionTokenExpiry = 0;       // derived (request time + ~15 min)
+};
+
+// ------------------------------------------------------------------
+// switch_uid serialization helpers (MUST match the Swift config app)
+// ------------------------------------------------------------------
+std::string accountUidToString(const AccountUid& uid);
+bool accountUidFromString(const std::string& s, AccountUid& out);
+
+// ------------------------------------------------------------------
+// Link storage
+// ------------------------------------------------------------------
+
+/**
+ * (Re)load all links from sdmc:/config/switchrpc_profiles.json.
+ * If that file is absent, falls back to the legacy single
+ * sdmc:/config/switchrpc_token as one default/wildcard link.
+ * Populates and returns the global link table. Safe to call only when no
+ * active Link pointer is being held (it clears/rebuilds the table).
+ */
+std::vector<Link>& loadLinks();
+
+/**
+ * Resolve a playing user's AccountUid to a link.
+ * Returns the exact switch_uid match if present, else the default/wildcard
+ * (all-zero) link if present, else nullptr (meaning: no presence).
+ * Returned pointer is valid until the next loadLinks() call.
+ */
+Link* resolveLink(const AccountUid& uid);
+
+/**
+ * Persist a (rotated) refresh token back to switchrpc_profiles.json for the
+ * link's switch_uid (preserving every other entry), or to the legacy
+ * switchrpc_token file if the links were loaded from legacy.
+ */
+void persistLinkRefreshToken(const Link& link);
+
+/**
+ * Refresh the link's auth token if it is missing/expired (rotates and
+ * persists the refresh token). Returns true if a usable auth token is held.
+ */
+bool refreshAuthTokenIfNeeded(Link& link);
 
 // ------------------------------------------------------------------
 // Public Discord API Functions
 // ------------------------------------------------------------------
 
 /**
- * Creates or updates a Discord Headless Session to show the current game.
- * 
- * @param titleId The Title ID of the currently running game.
- * @param includeToken Whether to include the current sessionToken in the request.
+ * Creates or updates a Discord Headless Session to show the current game for
+ * the given link's Discord account.
+ *
+ * @param link          The resolved link (owning Discord account).
+ * @param titleId       The Title ID of the currently running game.
+ * @param titleName     The display name of the running game.
+ * @param includeToken  Whether to include the link's current sessionToken.
+ * @return true only if a session token was successfully obtained and stored.
  */
-void discordCreateHeadlessSession(u64 titleId, std::string titleName, const bool includeToken);
+bool discordCreateHeadlessSession(Link& link, u64 titleId, std::string titleName, const bool includeToken);
 
 /**
- * Deletes the active Discord Headless Session.
- * Call this when the game closes or the sysmodule is exiting.
+ * Deletes the link's active Discord Headless Session.
+ * Call this when the game closes, the active link changes, or on exit.
  */
-void discordDeleteHeadlessSession();
+void discordDeleteHeadlessSession(Link& link);
 
 /**
- * Deletes all known sessions by clearing the sessions file.
- * Call this on startup or when waking from sleep to clean up any sessions that should no longer be active.
+ * Deletes all known sessions recorded in switchrpc_sessions.json, resolving
+ * each entry to its owning link (by switch_uid) for the correct credentials,
+ * then clears the file. A legacy plaintext sessions file is deleted
+ * best-effort. Requires loadLinks() to have been called first.
  */
 void discordCleanupStaleSessions();

--- a/Sources/SwitchRPC/source/main.cpp
+++ b/Sources/SwitchRPC/source/main.cpp
@@ -153,19 +153,36 @@ void __appInit(void)
 	nsInitialize();
 	setInitialize();
 
+	// account service: needed for accountGetLastOpenedUser() to resolve which
+	// Switch user is currently playing. Per the contract we use a System session;
+	// if a System session cannot call accountGetLastOpenedUser on a given
+	// firmware, switch this to AccountServiceType_Application.
+	rc = accountInitialize(AccountServiceType_System);
+	if (R_FAILED(rc))
+		writeToLog("[SwitchRPC] Warning: accountInitialize failed with 0x%08X. User resolution will fail.", rc);
+
     // Close the service manager session.
     smExit();
 }
 
+// the link whose headless session is currently active (points into the
+// discord.cpp link table). nullptr when no session is active. Kept at file
+// scope so __appExit can tear the active session down on process exit.
+static Link* g_activeLink = nullptr;
+
 // Service deinitialization.
 void __appExit(void)
 {
-    discordDeleteHeadlessSession();
+    if (g_activeLink != nullptr) {
+        discordDeleteHeadlessSession(*g_activeLink);
+        g_activeLink = nullptr;
+    }
     writeToLog("[SwitchRPC] Sysmodule exiting. Goodbye!");
 
     curl_global_cleanup();
 
     socketExit();
+    accountExit();
     setExit();
     nsExit();
     pmdmntExit();
@@ -182,69 +199,163 @@ void __appExit(void)
 #endif
 
 
-const int REFRESH_INTERVAL = 15 * 60; 
+const int REFRESH_INTERVAL = 15 * 60;
+
+// Enumerate every Switch user (uid + nickname) and write them to
+// sdmc:/config/switchrpc_users.json. The config app can't read the account
+// service when launched as an applet, so it reads this file instead.
+static void logAllSwitchUsers() {
+    AccountUid uids[8];
+    s32 total = 0;
+    Result rc = accountListAllUsers(uids, 8, &total);
+    writeToLog("[SwitchRPC] accountListAllUsers rc=0x%08X total=%d", (unsigned)rc, total);
+
+    json_object* root = json_object_new_object();
+    json_object* arr = json_object_new_array();
+
+    for (s32 i = 0; i < total && i < 8; i++) {
+        char nick[0x21] = {0};
+        AccountProfile profile;
+        if (R_SUCCEEDED(accountGetProfile(&profile, uids[i]))) {
+            AccountProfileBase base = {0};
+            if (R_SUCCEEDED(accountProfileGet(&profile, NULL, &base))) {
+                strncpy(nick, base.nickname, sizeof(nick) - 1);
+            }
+            accountProfileClose(&profile);
+        }
+        std::string uidStr = accountUidToString(uids[i]);
+        writeToLog("[SwitchRPC]   user[%d] uid=%s nick=%s", (int)i, uidStr.c_str(), nick);
+
+        json_object* u = json_object_new_object();
+        json_object_object_add(u, "uid", json_object_new_string(uidStr.c_str()));
+        json_object_object_add(u, "nickname", json_object_new_string(nick));
+        json_object_array_add(arr, u); // arr takes ownership
+    }
+
+    json_object_object_add(root, "users", arr); // root takes ownership
+    FILE* f = fopen("sdmc:/config/switchrpc_users.json", "w");
+    if (f) {
+        fputs(json_object_to_json_string(root), f);
+        fclose(f);
+        writeToLog("[SwitchRPC] Wrote switchrpc_users.json (%d user(s)).", (int)total);
+    } else {
+        writeToLog("[SwitchRPC] Failed to write switchrpc_users.json!");
+    }
+    json_object_put(root);
+}
 
 int main(int argc, char* argv[])
 {
     writeToLog("[SwitchRPC] Sysmodule started successfully.");
 
-    AppInfo lastInfo = {0};
+    // Active-session state (replaces the old single-account lastInfo model).
+    // g_activeLink (file scope) points to the link whose session is active, or
+    // nullptr when none is active. activeTid is the game tid that the active
+    // state corresponds to (tracked even when no link resolves, so we don't
+    // re-evaluate the same game every loop). last_update_time drives the
+    // periodic refresh.
+    u64 activeTid = 0;
     time_t last_update_time = 0;
 
-    // Start by cleaning up stale sessions 
+    // Load links, then clean up any sessions left over from a previous run
+    // (uses the just-loaded links to find the right credentials per session).
+    loadLinks();
+    logAllSwitchUsers();
     discordCleanupStaleSessions();
-    
+
     waitForNetworkReady();
     while (true) {
+        // Reload links whenever no session is active so newly-linked profiles
+        // are picked up. Safe only when g_activeLink is nullptr because
+        // loadLinks() rebuilds the table and would invalidate the pointer.
+        if (g_activeLink == nullptr) {
+            loadLinks();
+        }
+
         AppInfo info = {0};
         Result rc = get_app_info(&info);
-        
+
         bool is_game_running = R_SUCCEEDED(rc) && info.tid != 0;
 
         if (is_game_running) {
-            // user opened a game or switched a game or switched from home menu to game (tid changed)
-            if (info.tid != lastInfo.tid) {
-                // if lastInfo.tid != 0, we already had a session running, so we include the token to update it.
-                // if lastInfo.tid == 0, it's a brand new session, so no token is included.
-                bool has_existing_session = (lastInfo.tid != 0);
-                
-                writeToLog("[SwitchRPC] Game state changed! New TID: %016llX, Name: %s. Previous TID: %016llX", 
-                           (unsigned long long)info.tid, info.title_name, (unsigned long long)lastInfo.tid);
+            // Determine which Switch user is currently playing and resolve the
+            // link for that user (exact match, else default/wildcard, else none).
+            AccountUid uid = {0};
+            Result urc = accountGetLastOpenedUser(&uid);
+            if (R_FAILED(urc)) {
+                writeToLog("[SwitchRPC] accountGetLastOpenedUser failed (0x%08X); falling back to default link.", urc);
+                uid.uid[0] = 0; // zero -> resolveLink returns default/wildcard if present
+                uid.uid[1] = 0;
+            }
+            Link* resolved = resolveLink(uid);
 
-                lastInfo = info;
-                last_update_time = time(NULL);
-                
-                // create/update session.
-                discordCreateHeadlessSession(info.tid, std::string(info.title_name), has_existing_session);
-            } 
-            // the same game is still open. refresh.
-            else {
+            bool tidChanged = (info.tid != activeTid);
+            bool linkChanged = (resolved != g_activeLink);
+
+            if (tidChanged || linkChanged) {
+                writeToLog("[SwitchRPC] State change. New TID: %016llX (%s), prev TID: %016llX. Link changed: %s",
+                           (unsigned long long)info.tid, info.title_name,
+                           (unsigned long long)activeTid, linkChanged ? "yes" : "no");
+                writeToLog("[SwitchRPC] Detected playing user: rc=0x%08X uid=%s -> resolved link=%s",
+                           (unsigned)urc, accountUidToString(uid).c_str(),
+                           resolved ? resolved->switchUidStr.c_str() : "(none)");
+
+                // tear down the previous active session with the PREVIOUS link's
+                // credentials before switching identities.
+                if (g_activeLink != nullptr) {
+                    discordDeleteHeadlessSession(*g_activeLink);
+                    g_activeLink = nullptr;
+                }
+
+                if (resolved != nullptr) {
+                    // brand-new session for the resolved link (no token reuse).
+                    bool ok = discordCreateHeadlessSession(*resolved, info.tid, std::string(info.title_name), false);
+                    if (ok) {
+                        g_activeLink = resolved;
+                        last_update_time = time(NULL);
+                    } else {
+                        // create failed: stay inactive so the next loop retries
+                        // promptly (linkChanged stays true while g_activeLink is
+                        // null and a link still resolves).
+                        g_activeLink = nullptr;
+                        last_update_time = 0;
+                        writeToLog("[SwitchRPC] Session create failed; will retry shortly.");
+                    }
+                } else {
+                    writeToLog("[SwitchRPC] No link for the current user; not pushing presence.");
+                    last_update_time = 0;
+                }
+                // track the tid regardless so we don't re-evaluate every loop.
+                activeTid = info.tid;
+            }
+            // same game & same resolved link: periodic refresh.
+            else if (g_activeLink != nullptr) {
                 time_t current_time = time(NULL);
-                // check time interval
                 if (current_time - last_update_time >= REFRESH_INTERVAL) {
-                    writeToLog("[SwitchRPC] Periodic session refresh triggered for TID: %016llX", (unsigned long long)info.tid);
-                    last_update_time = current_time;
-                    
-                    // refresh session with session token that we have if any.
-                    discordCreateHeadlessSession(info.tid, std::string(info.title_name), true);
+                    writeToLog("[SwitchRPC] Periodic session refresh for TID: %016llX", (unsigned long long)info.tid);
+                    bool ok = discordCreateHeadlessSession(*g_activeLink, info.tid, std::string(info.title_name), true);
+                    if (ok) {
+                        last_update_time = current_time;
+                    }
+                    // on failure, leave last_update_time so the refresh retries on
+                    // the next loop instead of waiting another full interval.
                 }
             }
         } else {
-            // user isn't in a game. if we had a session before, delete it since the game closed, and reset lastInfo.
-            if (lastInfo.tid != 0) {
-                writeToLog("[SwitchRPC] Game closed or returned to Home Menu. Clearing session for TID: %016llX", (unsigned long long)lastInfo.tid);
+            // No game running. Tear down any active session, clear state.
+            if (g_activeLink != nullptr) {
+                writeToLog("[SwitchRPC] Game closed / Home Menu. Clearing active session.");
                 waitForNetworkReady();
-
-                lastInfo = {0};
-                last_update_time = 0;
-                
-                discordDeleteHeadlessSession();
+                discordDeleteHeadlessSession(*g_activeLink);
+                g_activeLink = nullptr;
             }
+            activeTid = 0;
+            last_update_time = 0;
         }
 
         // sleep detection
         time_t sleep_start = time(NULL);
-        svcSleepThread(10 * 1000 * 1000 * 1000ULL); 
+        svcSleepThread(10 * 1000 * 1000 * 1000ULL);
         time_t sleep_end = time(NULL);
 
         if (sleep_end - sleep_start > 15) {
@@ -252,8 +363,13 @@ int main(int argc, char* argv[])
             waitForNetworkReady();
             writeToLog("[SwitchRPC] Network ready after sleep, clearing sessions.");
 
-            last_update_time = 0; 
-            discordCleanupStaleSessions(); // cleanup any sessions we created prior.
+            // drop active state (its session may be invalid after sleep), then
+            // reload links and clean up everything recorded on disk.
+            g_activeLink = nullptr;
+            activeTid = 0;
+            last_update_time = 0;
+            loadLinks();
+            discordCleanupStaleSessions();
         }
     }
 

--- a/Sources/SwitchRPCConfig/App/App.swift
+++ b/Sources/SwitchRPCConfig/App/App.swift
@@ -14,6 +14,7 @@ struct App: NXApp {
 
 	mutating func runloop(_ ctx: inout RunLoopContext) {  // runs in a loop, calling ctx.exit() ends the app
 		ctx.pad.update()
+		menu.setupIfNeeded()
 		menu.tick(&ctx)
 
 		if menu.wasInvalidated {
@@ -57,36 +58,24 @@ struct App: NXApp {
 	}
 }
 
+/// One selectable row in the profile menu (a Switch user, or the default).
+struct ProfileEntry {
+	var uid: String        // switch_uid string
+	var nickname: String   // display name
+	var isDefault: Bool    // true for the "Default (all profiles)" pseudo-entry
+}
+
 struct Menu {
 	var wasInvalidated = true  // redraw flag
 
 	// Menu state variables
-	var isLoggedIn = checkLogin()
-	// var sysmoduleEnabled = Utilities.isSysmoduleRunning(titleId: sysmoduleTitleId) {
-	// 	didSet {
-	// 		if sysmoduleEnabled {
-	// 			Utilities.startSysmodule(titleId: sysmoduleTitleId)
-	// 			log("Sysmodule enabled")
-	// 		} else {
-	// 			Utilities.stopSysmodule(titleId: sysmoduleTitleId)
-	// 			log("Sysmodule disabled")
-	// 		}
-	// 		Utilities.setSysmoduleAutoBoot(titleId: sysmoduleTitleId, enable: sysmoduleEnabled)
-	// 	}
-	// }
 	var selectedIndex = 0
+	var didSetup = false
 
-	static func checkLogin() -> Bool {
-		let path = "sdmc:/config/switchrpc_token"
-		if let file = fopen(path, "r") {
-			var tokenBuffer = [CChar](repeating: 0, count: 512)
-			fgets(&tokenBuffer, Int32(tokenBuffer.count), file)
-			fclose(file)
-			let token = String(cStr: tokenBuffer)
-			return !token.isEmpty
-		}
-		return false
-	}
+	/// Switch profiles plus the trailing default pseudo-entry.
+	var entries: [ProfileEntry] = []
+	/// Current Switch -> Discord links, for status display.
+	var links: [Link] = []
 
 	var logs: [String] = [] {
 		didSet {
@@ -97,15 +86,91 @@ struct Menu {
 		}
 	}
 
-	// Computed menu options depending on context
-	var currentOptions: [String] {
-		[
-			isLoggedIn ? "Log out" : "Log in",
-			// sysmoduleEnabled ? "Disable sysmodule" : "Enable sysmodule",
-			"Exit app",
-			// "[DEBUG] Get current process",
-		]
+	// MARK: - Setup / reload
+
+	mutating func setupIfNeeded() {
+		if didSetup { return }
+		didSetup = true
+		ProfileStore.migrateLegacyIfNeeded()
+		reload()
 	}
+
+	mutating func reload() {
+		self.links = ProfileStore.load()
+		self.entries = Menu.enumerateProfiles()
+		// keep the selection in range (entries + trailing "Exit app")
+		let count = entries.count + 1
+		if selectedIndex >= count { selectedIndex = 0 }
+		self.wasInvalidated = true
+	}
+
+	/// Build the profile list: the Switch users (read from switchrpc_users.json,
+	/// which the sysmodule writes because the config app can't read the account
+	/// service when launched as an applet), then the "Default" pseudo-entry.
+	static func enumerateProfiles() -> [ProfileEntry] {
+		var result: [ProfileEntry] = []
+
+		let users = ProfileStore.loadSwitchUsers()
+		for u in users {
+			result.append(
+				ProfileEntry(uid: u.uid, nickname: u.nickname, isDefault: false)
+			)
+		}
+
+		// Fallback: if that file isn't present yet (sysmodule hasn't run), try the
+		// account service directly — only works if launched in application mode.
+		if users.isEmpty {
+			var uids = [AccountUid](repeating: AccountUid(), count: 8)
+			var total: Int32 = 0
+			if accountListAllUsers(&uids, 8, &total).succeeded {
+				var i = 0
+				while i < Int(total) && i < uids.count {
+					let uid = uids[i]
+					result.append(
+						ProfileEntry(
+							uid: ProfileStore.uidToString(uid),
+							nickname: getNickname(uid) ?? "Unknown",
+							isDefault: false
+						)
+					)
+					i += 1
+				}
+			}
+		}
+
+		result.append(
+			ProfileEntry(
+				uid: ProfileStore.defaultUid,
+				nickname: "Default (all profiles)",
+				isDefault: true
+			)
+		)
+		return result
+	}
+
+	/// Read a Switch user's nickname via accountGetProfile/accountProfileGet.
+	static func getNickname(_ uid: AccountUid) -> String? {
+		var profile = AccountProfile()
+		guard accountGetProfile(&profile, uid).succeeded else { return nil }
+		defer { accountProfileClose(&profile) }
+		var base = AccountProfileBase()
+		guard accountProfileGet(&profile, nil, &base).succeeded else { return nil }
+		let nickname = withUnsafeBytes(of: base.nickname) { rawPtr -> String in
+			let buffer = rawPtr.bindMemory(to: CChar.self)
+			return String(cString: buffer.baseAddress!)
+		}
+		return nickname.isEmpty ? nil : nickname
+	}
+
+	/// Find the link for a given switch_uid, if any.
+	func linkFor(_ uid: String) -> Link? {
+		for link in links {
+			if link.switchUid == uid { return link }
+		}
+		return nil
+	}
+
+	// MARK: - Input
 
 	mutating func tick(_ ctx: inout RunLoopContext) {
 		// Handle exit request
@@ -113,33 +178,44 @@ struct Menu {
 			ctx.exit()
 			return
 		}
-		
+
+		let count = entries.count + 1  // +1 for trailing "Exit app"
+
 		// Move selection
 		if ctx.pad.wasButtonPressed(.anyDown) {
 			self.wasInvalidated = true
-			selectedIndex = (selectedIndex + 1) % currentOptions.count
+			selectedIndex = (selectedIndex + 1) % count
 		}
 		if ctx.pad.wasButtonPressed(.anyUp) {
 			self.wasInvalidated = true
-			selectedIndex =
-				(selectedIndex - 1 + currentOptions.count) % currentOptions.count
+			selectedIndex = (selectedIndex - 1 + count) % count
 		}
 
-		// Select option
+		// A: link/relink a profile, or exit on the trailing row
 		if ctx.pad.wasButtonPressed(.a) {
 			self.wasInvalidated = true
-			switch selectedIndex {
-			// log in/log out
-			case 0: self.isLoggedIn ? self.logOut() : self.logIn()
-			// case 1: sysmoduleEnabled.toggle()
-			case 1: ctx.exit()
-			// case 3: process()
-			default: break
+			if selectedIndex < entries.count {
+				linkFlow(for: entries[selectedIndex], &ctx)
+			} else {
+				ctx.exit()
+			}
+		}
+
+		// X: unlink a linked profile
+		if ctx.pad.wasButtonPressed(.x) {
+			if selectedIndex < entries.count {
+				let entry = entries[selectedIndex]
+				if linkFor(entry.uid) != nil {
+					self.wasInvalidated = true
+					unlink(entry)
+				}
 			}
 		}
 	}
 
-	mutating func logIn() {
+	// MARK: - Link flow
+
+	mutating func linkFlow(for entry: ProfileEntry, _ ctx: inout RunLoopContext) {
 		//		 --- Start server ---
 		let serverWork: ThreadFunc = { conf in
 			App.server.start()
@@ -170,46 +246,59 @@ struct Menu {
 
 		App.server.codeChallenge = codeChallenge
 		App.server.state = state
-
-		// // urls
-		// let authURL =
-		// 	"https://discord.com/oauth2/authorize?client_id=\(DiscordConsts.ClientID)&response_type=code&scope=\(Request.URLEncode(DiscordConsts.scope))&code_challenge=\(codeChallenge)&code_challenge_method=\("S256")&state=\(state)&redirect_uri=\(Request.URLEncode(DiscordConsts.redirectURI))"
-
-		// let url =
-		// 	"https://static.llsc12.me/discord?ip=\(deviceIP)&auth=\(Request.URLEncode(authURL))"
-
-		// // Create web page with QR code for user
-		// App.webConfig = .init()
-		// var reply = WebCommonReply()
-		// _ = webPageCreate(
-		// 	&App.webConfig,
-		// 	"https://static.llsc12.me/discord/qr?url=\(Request.URLEncode(url))",
-		// )
-		// webConfigSetJsExtension(&App.webConfig, true)
-		// webConfigSetPageCache(&App.webConfig, true)
-		// webConfigSetBootLoadingIcon(&App.webConfig, true)
-		// webConfigSetWhitelist(&App.webConfig, ".*")
-		// _ = webConfigShow(&App.webConfig, &reply)  // this blocks until the user closes the web page, but other thread will close it after 5 seconds to free this one
-		// //				var exitReason = WebExitReason_UnknownE
-		// //				webReplyGetExitReason(&reply, &exitReason)
-		// using exitreason isnt working no clue why, so ill check if server is still running instead
-
+		App.server.code = nil  // clear any stale code from a previous attempt
 
 		_ = threadCreate(&thread, serverWork, nil, nil, 0x4000, 0x3B, 2)
 		threadStart(&thread)
 
 		let url = "http://\(deviceIP):45601"
-		log("Enter this url into your browser to log in:\n\n\(url)", rd: true)
+
+		// Render an on-device QR code for the pairing URL, with the URL printed
+		// below as a fallback. (QRCode is owned by the QR agent.)
+		consoleClear()
+		print("\nLink \(entry.nickname) to Discord\n")
+		if let matrix = QRCode.encode(url) {
+			QRCode.render(matrix)
+		}
+		print("\nScan the QR code with your phone, or open this URL in a browser:\n")
+		print(url)
+		print("\nPress B to cancel.")
 		consoleUpdate(nil)  // push new frame
+
+		// Wait for the pairing callback, but let the user cancel with B or time
+		// out, so the app never freezes if pairing is never completed.
+		var waitedMs = 0
+		let timeoutMs = 180_000  // 3 minutes
+		while App.server.isRunning {
+			ctx.pad.update()
+			if ctx.pad.wasButtonPressed(.b) {
+				App.server.stop()
+				log("Pairing cancelled.", rd: true)
+				break
+			}
+			if waitedMs >= timeoutMs {
+				App.server.stop()
+				log("Pairing timed out.", rd: true)
+				break
+			}
+			Thread.sleep(for: .milliseconds(16))
+			waitedMs += 16
+		}
 
 		threadWaitForExit(&thread)
 		threadClose(&thread)  // cleanup
 
+		let dcode = App.server.code
+
+		// No code means the user cancelled or it timed out; just redraw.
+		guard dcode != nil else {
+			reload()
+			return
+		}
 		guard App.server.state == state else {
 			log("State mismatch, stopping...\n", rd: true)
 			return
 		}
-		let dcode = App.server.code
 
 		log("\nReceived auth data, retrieving tokens...", rd: true)
 
@@ -217,19 +306,21 @@ struct Menu {
 			do {
 				try App.discord.authenticate(code: code, codeVerifier: codeVerifier)
 
-				let me = try App.discord.me()
-				let username = me["user"]["username"].string ?? "Unknown User"
+				let user = try App.discord.meUser()
+				let username = user.username.isEmpty ? "Unknown User" : user.username
 				log("Hello, \(username)!")
 
-				// save token to file for later use
+				// upsert the link for the chosen switch_uid
 				if let token = App.discord.auth?.refreshToken {
-					// save using fs module
-					let path = "sdmc:/config/switchrpc_token"
-					if let file = fopen(path, "w") {
-						fputs(token, file)
-						fclose(file)
-					}
-					isLoggedIn = true
+					let link = Link(
+						switchUid: entry.uid,
+						switchNickname: entry.nickname,
+						discordId: user.id,
+						discordUsername: username,
+						refreshToken: token
+					)
+					ProfileStore.upsert(link)
+					reload()
 				}
 			} catch {
 				log("Failed: \(error.errorDescription ?? "Unknown error")")
@@ -237,17 +328,10 @@ struct Menu {
 		}
 	}
 
-	mutating func logOut() {
-		// delete token file
-		let path = "sdmc:/config/switchrpc_token"
-		remove(path)
-		isLoggedIn = false
-		log("Logged out", rd: true)
-	}
-
-	mutating func process() {
-		let data = Utilities.GetCurrentProcessData()
-		log("app: \(data?.title ?? "No App Open")")
+	mutating func unlink(_ entry: ProfileEntry) {
+		ProfileStore.removeLink(switchUid: entry.uid)
+		log("Unlinked \(entry.nickname)", rd: true)
+		reload()
 	}
 
 	mutating func log(_ message: String, rd: Bool = false) {
@@ -259,21 +343,33 @@ struct Menu {
 extension Menu {
 	mutating func draw() {
 		print("\nSwitchRPC\n")
-		for (i, line) in self.currentOptions.enumerated() {
+		print("Select a profile, then press A to link Discord.\n")
+
+		for (i, entry) in self.entries.enumerated() {
 			let selector = (i == self.selectedIndex) ? "-> " : "   "
-			print("  \(selector)\(line)")
+			let status: String
+			if let link = linkFor(entry.uid), !link.discordUsername.isEmpty {
+				status = "Discord: \(link.discordUsername)"
+			} else if linkFor(entry.uid) != nil {
+				status = "Discord: linked"
+			} else {
+				status = "not linked"
+			}
+			print("  \(selector)\(entry.nickname)  [\(status)]")
 		}
-		print("\n\n")
-		print("By llsc12")
+
+		// trailing "Exit app" row
+		let exitIndex = self.entries.count
+		let exitSelector = (self.selectedIndex == exitIndex) ? "-> " : "   "
+		print("  \(exitSelector)Exit app")
+
 		print("\n")
-		print(
-			"[ Logs ]\n"
-		)
+		print("A: link/relink    X: unlink    +: exit")
+		print("\nBy llsc12\n")
+		print("[ Logs ]\n")
 		for log in self.logs {
 			print(log)
 		}
-
-		print("\n\n\n\n\n                    yop")
 	}
 
 	mutating func forceRedraw() {

--- a/Sources/SwitchRPCConfig/App/Discord.swift
+++ b/Sources/SwitchRPCConfig/App/Discord.swift
@@ -19,7 +19,7 @@ class Discord {
 	
 	func me() throws(DiscordError) -> JSONValue {
 		let auth = try checkAuth()
-		
+
 		var res: Response
 		do {
 			res = try Request(url: "https://gaming-sdk.com/api/v9/oauth2/@me")
@@ -29,8 +29,31 @@ class Discord {
 		} catch {
 			throw .requestError(error)
 		}
-		
+
 		return .parse(from: res.data) ?? JSONValue.object([:])
+	}
+
+	/// The current Discord user's id + username, parsed from `me()`.
+	struct MeUser {
+		var id: String
+		var username: String
+	}
+
+	/// Fetches the authenticated Discord user, exposing the id and username
+	/// so callers can persist them into a Link.
+	func meUser() throws(DiscordError) -> MeUser {
+		let json = try me()
+		// The gaming-sdk @me response nests the account under "user"; tolerate a
+		// flat shape (id/username at top level) as a fallback just in case.
+		var username = json["user"]["username"].string ?? ""
+		if username.isEmpty { username = json["username"].string ?? "" }
+		var id = json["user"]["id"].string ?? ""
+		if id.isEmpty { id = json["id"].string ?? "" }
+		// Discord ids are usually strings, but tolerate a numeric form too.
+		if id.isEmpty, let intId = json["user"]["id"].int ?? json["id"].int {
+			id = "\(intId)"
+		}
+		return MeUser(id: id, username: username)
 	}
 
 	@discardableResult

--- a/Sources/SwitchRPCConfig/App/ProfileStore.swift
+++ b/Sources/SwitchRPCConfig/App/ProfileStore.swift
@@ -1,0 +1,240 @@
+//
+//  ProfileStore.swift
+//  SwitchRPC
+//
+//  Store over sdmc:/config/switchrpc_profiles.json linking Switch user
+//  profiles to Discord accounts. See SHARED CONTRACT (v1).
+//
+
+import devkitpro  // C stdio: fopen/fclose/fgets/fputs/fread/remove
+import libnx
+
+/// One Switch-user -> Discord link entry.
+struct Link {
+	var switchUid: String        // "<16hex>-<16hex>" (all-zero = default/wildcard)
+	var switchNickname: String   // display only
+	var discordId: String        // discord user id, may be ""
+	var discordUsername: String  // display only
+	var refreshToken: String     // discord OAuth refresh token (rotates)
+}
+
+/// A Switch user reported by the sysmodule via switchrpc_users.json.
+struct SwitchUser {
+	var uid: String
+	var nickname: String
+}
+
+enum ProfileStore {
+	static let profilesPath = "sdmc:/config/switchrpc_profiles.json"
+	static let legacyTokenPath = "sdmc:/config/switchrpc_token"
+	/// Switch user list, written by the sysmodule (which has account access).
+	static let usersPath = "sdmc:/config/switchrpc_users.json"
+	/// all-zero uid string == DEFAULT / wildcard link
+	static let defaultUid = "0000000000000000-0000000000000000"
+
+	// MARK: - AccountUid <-> switch_uid string
+
+	/// Lowercase, zero-padded 16-char hex for a UInt64.
+	static func hex16(_ value: UInt64) -> String {
+		let hexChars: [UInt8] = Array("0123456789abcdef".utf8)
+		var out = [UInt8](repeating: 0, count: 17)
+		var v = value
+		var i = 15
+		while i >= 0 {
+			out[i] = hexChars[Int(v & 0xF)]
+			v >>= 4
+			i -= 1
+		}
+		out[16] = 0  // null-terminate
+		return String(cStr: out)
+	}
+
+	/// Parse a hex substring into a UInt64, or nil if invalid.
+	static func parseHex(_ s: Substring) -> UInt64? {
+		if s.isEmpty { return nil }
+		var result: UInt64 = 0
+		for ch in s.utf8 {
+			let digit: UInt64
+			switch ch {
+			case 0x30...0x39: digit = UInt64(ch - 0x30)         // 0-9
+			case 0x61...0x66: digit = UInt64(ch - 0x61 + 10)    // a-f
+			case 0x41...0x46: digit = UInt64(ch - 0x41 + 10)    // A-F
+			default: return nil
+			}
+			result = (result << 4) | digit
+		}
+		return result
+	}
+
+	/// "%016llx-%016llx" of uid.uid[0], uid.uid[1].
+	static func uidToString(_ uid: AccountUid) -> String {
+		return hex16(uid.uid.0) + "-" + hex16(uid.uid.1)
+	}
+
+	/// Parse a switch_uid string back into an AccountUid.
+	static func stringToUid(_ s: String) -> AccountUid? {
+		let parts = s.split(separator: "-")
+		guard parts.count == 2 else { return nil }
+		guard let hi = parseHex(parts[0]), let lo = parseHex(parts[1]) else {
+			return nil
+		}
+		var uid = AccountUid()
+		uid.uid.0 = hi
+		uid.uid.1 = lo
+		return uid
+	}
+
+	// MARK: - Raw file IO
+
+	static func fileExists(_ path: String) -> Bool {
+		if let f = fopen(path, "r") {
+			fclose(f)
+			return true
+		}
+		return false
+	}
+
+	static func readFile(_ path: String) -> String? {
+		guard let file = fopen(path, "rb") else { return nil }
+		defer { fclose(file) }
+		var data = [UInt8]()
+		var chunk = [UInt8](repeating: 0, count: 4096)
+		while true {
+			let n = fread(&chunk, 1, chunk.count, file)
+			if n <= 0 { break }
+			data.append(contentsOf: chunk[0..<n])
+		}
+		if data.isEmpty { return nil }
+		data.append(0)  // null-terminate
+		return String(cStr: data)
+	}
+
+	static func writeFile(_ path: String, _ content: String) {
+		if let file = fopen(path, "w") {
+			fputs(content, file)
+			fclose(file)
+		}
+	}
+
+	// MARK: - Load / Save
+
+	/// Switch users as enumerated by the sysmodule and written to disk.
+	static func loadSwitchUsers() -> [SwitchUser] {
+		guard let content = readFile(usersPath) else { return [] }
+		guard let json = JSONValue.parse(from: content) else { return [] }
+		guard let arr = json["users"].array else { return [] }
+		var users: [SwitchUser] = []
+		for item in arr {
+			let uid = item["uid"].string ?? ""
+			if uid.isEmpty { continue }
+			users.append(
+				SwitchUser(uid: uid, nickname: item["nickname"].string ?? "Unknown")
+			)
+		}
+		return users
+	}
+
+	static func load() -> [Link] {
+		guard let content = readFile(profilesPath) else { return [] }
+		guard let json = JSONValue.parse(from: content) else { return [] }
+		guard let arr = json["links"].array else { return [] }
+		var links: [Link] = []
+		for item in arr {
+			let su = item["switch_uid"].string ?? ""
+			if su.isEmpty { continue }
+			links.append(
+				Link(
+					switchUid: su,
+					switchNickname: item["switch_nickname"].string ?? "",
+					discordId: item["discord_id"].string ?? "",
+					discordUsername: item["discord_username"].string ?? "",
+					refreshToken: item["refresh_token"].string ?? ""
+				)
+			)
+		}
+		return links
+	}
+
+	static func save(_ links: [Link]) {
+		var arr: [JSONValue] = []
+		for link in links {
+			let obj: [String: JSONValue] = [
+				"switch_uid": JSONValue(link.switchUid),
+				"switch_nickname": JSONValue(link.switchNickname),
+				"discord_id": JSONValue(link.discordId),
+				"discord_username": JSONValue(link.discordUsername),
+				"refresh_token": JSONValue(link.refreshToken),
+			]
+			arr.append(JSONValue(obj))
+		}
+		let root: [String: JSONValue] = [
+			"version": JSONValue(1),
+			"links": JSONValue(arr),
+		]
+		guard let str = JSONValue(root).stringify() else { return }
+		writeFile(profilesPath, str)
+	}
+
+	/// Insert or replace a link by switch_uid, preserving all others.
+	static func upsert(_ link: Link) {
+		var links = load()
+		var found = false
+		for i in 0..<links.count {
+			if links[i].switchUid == link.switchUid {
+				links[i] = link
+				found = true
+				break
+			}
+		}
+		if !found { links.append(link) }
+		save(links)
+	}
+
+	/// Remove the link with the given switch_uid, preserving all others.
+	/// Named `removeLink` (not `remove`) so it does not shadow the C stdio
+	/// `remove(path)` used by `migrateLegacyIfNeeded()` below.
+	static func removeLink(switchUid: String) {
+		var links = load()
+		links.removeAll { $0.switchUid == switchUid }
+		save(links)
+	}
+
+	// MARK: - Legacy migration (owned by the config app)
+
+	/// Read the legacy single-token file, trimming trailing whitespace.
+	static func readLegacyToken() -> String? {
+		guard let file = fopen(legacyTokenPath, "r") else { return nil }
+		var tokenBuffer = [CChar](repeating: 0, count: 1024)
+		fgets(&tokenBuffer, Int32(tokenBuffer.count), file)
+		fclose(file)
+		var token = String(cStr: tokenBuffer)
+		while let last = token.last,
+			last == "\n" || last == "\r" || last == " " || last == "\t"
+		{
+			token.removeLast()
+		}
+		return token.isEmpty ? nil : token
+	}
+
+	/// If profiles.json is absent but a non-empty legacy token exists, create
+	/// profiles.json with a single default/wildcard link, then delete the
+	/// legacy token only after profiles.json is written successfully.
+	static func migrateLegacyIfNeeded() {
+		if fileExists(profilesPath) { return }
+		guard let token = readLegacyToken() else { return }
+
+		let link = Link(
+			switchUid: defaultUid,
+			switchNickname: "Default",
+			discordId: "",
+			discordUsername: "",
+			refreshToken: token
+		)
+		save([link])
+
+		// only delete the legacy file once profiles.json is on disk
+		if fileExists(profilesPath) {
+			remove(legacyTokenPath)  // C stdio remove(path)
+		}
+	}
+}

--- a/Sources/SwitchRPCConfig/Makefile
+++ b/Sources/SwitchRPCConfig/Makefile
@@ -66,8 +66,14 @@ LIBS := -lnx `curl-config --libs` -ljson-c
 
 # Swift specific flags
 CFLAGS += -DNXApp
-# SWIFTC := swiftc
-SWIFT_TOOLCHAIN := /Users/lakhanlothiyi/Library/Developer/Toolchains/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-09-a.xctoolchain
+# Embedded Swift toolchain (a Swift development snapshot with Embedded support).
+# Override explicitly:  make SWIFT_TOOLCHAIN=/path/to/your.xctoolchain
+# or `export SWIFT_TOOLCHAIN=...`; otherwise auto-detect the newest snapshot
+# installed in ~/Library/Developer/Toolchains (macOS).
+SWIFT_TOOLCHAIN ?= $(lastword $(sort $(wildcard $(HOME)/Library/Developer/Toolchains/*.xctoolchain /Library/Developer/Toolchains/*.xctoolchain)))
+ifeq ($(strip $(SWIFT_TOOLCHAIN)),)
+$(error No Swift toolchain found. Install a Swift snapshot to ~/Library/Developer/Toolchains or set SWIFT_TOOLCHAIN=/path/to/your.xctoolchain)
+endif
 SWIFTC := $(SWIFT_TOOLCHAIN)/usr/bin/swiftc
 UNICODE_SUPPORT = $(SWIFT_TOOLCHAIN)/usr/lib/swift/embedded/aarch64-none-none-elf/libswiftUnicodeDataTables.a
 
@@ -261,7 +267,7 @@ $(OFILES_SRC)	: $(HFILES_BIN)
 
 $(OBJ_DIR)/app.o: $(LL_DIR)/app.ll
 	@mkdir -p $(OBJ_DIR)
-	@clang -target aarch64 -fpic -ffreestanding \
+	@$(SWIFT_TOOLCHAIN)/usr/bin/clang -target aarch64 -fpic -ffreestanding \
 		-c $(LL_DIR)/app.ll -o $(OBJ_DIR)/app.o
 
 $(LL_DIR)/app.ll: $(SWIFT_SRCS)

--- a/Sources/SwitchRPCConfig/Utils/QRCode.swift
+++ b/Sources/SwitchRPCConfig/Utils/QRCode.swift
@@ -1,0 +1,581 @@
+//
+//  QRCode.swift
+//  SwitchRPC
+//
+//  Self-contained QR Code (Model 2) encoder + console renderer.
+//  Byte (8-bit) mode only. Reed-Solomon ECC over GF(256). Supports versions 1...10.
+//
+//  Embedded-Swift safe: no Foundation, no libnx. The pure encoding logic also
+//  compiles under host swiftc so it can be diffed against an oracle (e.g. segno).
+//
+
+enum QRCode {
+	// MARK: - Public API
+
+	enum ECC {
+		case l, m, q, h
+	}
+
+	/// Encode `text` (UTF-8, byte mode) picking the smallest version that fits at
+	/// ECC level M, falling back to L only if no version 1...10 fits at M.
+	/// Full mask selection (lowest penalty, tie -> lowest index). The returned
+	/// matrix has NO quiet zone; `true` = dark. Returns nil if the text is too long.
+	static func encode(_ text: String) -> [[Bool]]? {
+		let data = Array(text.utf8)
+
+		var chosenV = 0
+		var chosenEcc: ECC = .m
+		for v in 1...10 {
+			if fits(data.count, v, .m) { chosenV = v; chosenEcc = .m; break }
+		}
+		if chosenV == 0 {
+			for v in 1...10 {
+				if fits(data.count, v, .l) { chosenV = v; chosenEcc = .l; break }
+			}
+		}
+		if chosenV == 0 { return nil }
+
+		guard let interleaved = buildCodewords(data, chosenV, chosenEcc) else { return nil }
+
+		// Mask selection is evaluated WITHOUT format/version/dark modules placed
+		// (ISO 18004 7.8.3); lowest penalty wins, ties resolve to the lowest index.
+		var bestMask = 0
+		var bestPenalty = Int.max
+		for m in 0..<8 {
+			let evalMat = buildMatrix(interleaved, chosenV, chosenEcc, m, eval: true)
+			let p = penalty(evalMat)
+			if p < bestPenalty {
+				bestPenalty = p
+				bestMask = m
+			}
+		}
+		return buildMatrix(interleaved, chosenV, chosenEcc, bestMask)
+	}
+
+	/// Host-testable forced-parameter encoder. Returns nil if the parameters are
+	/// out of range or the text does not fit the requested version/ecc.
+	static func encodeForced(_ text: String, version: Int, ecc: ECC, mask: Int) -> [[Bool]]? {
+		if version < 1 || version > 10 { return nil }
+		if mask < 0 || mask > 7 { return nil }
+		let data = Array(text.utf8)
+		if !fits(data.count, version, ecc) { return nil }
+		guard let interleaved = buildCodewords(data, version, ecc) else { return nil }
+		return buildMatrix(interleaved, version, ecc, mask)
+	}
+
+	/// Render a (quiet-zone-free) matrix to stdout/libnx console, dark-on-light,
+	/// with a 4-module quiet zone. Each module is ONE space painted with a VT
+	/// background color (light = ESC[47m, dark = ESC[40m), reset at the end of each
+	/// line. The caller is responsible for consoleClear/consoleUpdate.
+	static func render(_ matrix: [[Bool]]) {
+		let n = matrix.count
+		if n == 0 { return }
+		let quiet = 4
+		let total = n + quiet * 2
+		let lightSeq = "\u{1B}[47m"
+		let darkSeq = "\u{1B}[40m"
+		let reset = "\u{1B}[0m"
+
+		func renderRow(_ isDark: (Int) -> Bool) {
+			var line = ""
+			var current = false
+			var started = false
+			for c in 0..<total {
+				let dark = isDark(c)
+				if !started || dark != current {
+					line += dark ? darkSeq : lightSeq
+					current = dark
+					started = true
+				}
+				line += " "
+			}
+			line += reset
+			print(line)
+		}
+
+		for _ in 0..<quiet { renderRow { _ in false } }
+		for r in 0..<n {
+			let row = matrix[r]
+			renderRow { c in
+				if c < quiet || c >= quiet + n { return false }
+				return row[c - quiet]
+			}
+		}
+		for _ in 0..<quiet { renderRow { _ in false } }
+	}
+
+	// MARK: - Capacity / EC tables
+
+	/// (ec codewords per block, group1 blocks, group1 data cw, group2 blocks, group2 data cw)
+	static func eccTable(_ version: Int, _ ecc: ECC) -> (ec: Int, b1: Int, d1: Int, b2: Int, d2: Int) {
+		switch version {
+		case 1:
+			switch ecc { case .l: return (7,1,19,0,0); case .m: return (10,1,16,0,0); case .q: return (13,1,13,0,0); case .h: return (17,1,9,0,0) }
+		case 2:
+			switch ecc { case .l: return (10,1,34,0,0); case .m: return (16,1,28,0,0); case .q: return (22,1,22,0,0); case .h: return (28,1,16,0,0) }
+		case 3:
+			switch ecc { case .l: return (15,1,55,0,0); case .m: return (26,1,44,0,0); case .q: return (18,2,17,0,0); case .h: return (22,2,13,0,0) }
+		case 4:
+			switch ecc { case .l: return (20,1,80,0,0); case .m: return (18,2,32,0,0); case .q: return (26,2,24,0,0); case .h: return (16,4,9,0,0) }
+		case 5:
+			switch ecc { case .l: return (26,1,108,0,0); case .m: return (24,2,43,0,0); case .q: return (18,2,15,2,16); case .h: return (22,2,11,2,12) }
+		case 6:
+			switch ecc { case .l: return (18,2,68,0,0); case .m: return (16,4,27,0,0); case .q: return (24,4,19,0,0); case .h: return (28,4,15,0,0) }
+		case 7:
+			switch ecc { case .l: return (20,2,78,0,0); case .m: return (18,4,31,0,0); case .q: return (18,2,14,4,15); case .h: return (26,4,13,1,14) }
+		case 8:
+			switch ecc { case .l: return (24,2,97,0,0); case .m: return (22,2,38,2,39); case .q: return (22,4,18,2,19); case .h: return (26,4,14,2,15) }
+		case 9:
+			switch ecc { case .l: return (30,2,116,0,0); case .m: return (22,3,36,2,37); case .q: return (20,4,16,4,17); case .h: return (24,4,12,4,13) }
+		case 10:
+			switch ecc { case .l: return (18,2,68,2,69); case .m: return (26,4,43,1,44); case .q: return (24,6,19,2,20); case .h: return (28,6,15,2,16) }
+		default:
+			return (0,0,0,0,0)
+		}
+	}
+
+	static func alignmentPositions(_ v: Int) -> [Int] {
+		switch v {
+		case 2: return [6, 18]
+		case 3: return [6, 22]
+		case 4: return [6, 26]
+		case 5: return [6, 30]
+		case 6: return [6, 34]
+		case 7: return [6, 22, 38]
+		case 8: return [6, 24, 42]
+		case 9: return [6, 26, 46]
+		case 10: return [6, 28, 50]
+		default: return []
+		}
+	}
+
+	static func charCountBits(_ version: Int) -> Int {
+		// byte mode: 8 bits for versions 1...9, 16 bits for 10...40
+		return version < 10 ? 8 : 16
+	}
+
+	static func fits(_ len: Int, _ v: Int, _ ecc: ECC) -> Bool {
+		let t = eccTable(v, ecc)
+		let totalDataCW = t.b1 * t.d1 + t.b2 * t.d2
+		let required = 4 + charCountBits(v) + 8 * len
+		return required <= totalDataCW * 8
+	}
+
+	// MARK: - GF(256) / Reed-Solomon
+
+	static func gfTables() -> (exp: [Int], log: [Int]) {
+		var exp = [Int](repeating: 0, count: 512)
+		var log = [Int](repeating: 0, count: 256)
+		var x = 1
+		for i in 0..<255 {
+			exp[i] = x
+			log[x] = i
+			x <<= 1
+			if x & 0x100 != 0 { x ^= 0x11D }
+		}
+		for i in 255..<512 { exp[i] = exp[i - 255] }
+		return (exp, log)
+	}
+
+	static func gfMul(_ a: Int, _ b: Int, _ exp: [Int], _ log: [Int]) -> Int {
+		if a == 0 || b == 0 { return 0 }
+		return exp[log[a] + log[b]]
+	}
+
+	/// Generator polynomial coefficients (field values), length degree+1, index 0 = leading (x^degree).
+	static func rsGenerator(_ degree: Int, _ exp: [Int], _ log: [Int]) -> [Int] {
+		var poly: [Int] = [1]
+		for i in 0..<degree {
+			let alpha = exp[i]
+			var next = [Int](repeating: 0, count: poly.count + 1)
+			for j in 0..<poly.count {
+				next[j] ^= poly[j]
+				next[j + 1] ^= gfMul(poly[j], alpha, exp, log)
+			}
+			poly = next
+		}
+		return poly
+	}
+
+	static func rsEncode(_ data: [UInt8], _ ecCount: Int, _ exp: [Int], _ log: [Int]) -> [UInt8] {
+		let gen = rsGenerator(ecCount, exp, log) // length ecCount+1, gen[0] == 1
+		var rem = [Int](repeating: 0, count: ecCount)
+		for byte in data {
+			let factor = Int(byte) ^ rem[0]
+			var i = 0
+			while i < ecCount - 1 {
+				rem[i] = rem[i + 1]
+				i += 1
+			}
+			rem[ecCount - 1] = 0
+			if factor != 0 {
+				for k in 0..<ecCount {
+					rem[k] ^= gfMul(gen[k + 1], factor, exp, log)
+				}
+			}
+		}
+		var out = [UInt8](repeating: 0, count: ecCount)
+		for i in 0..<ecCount { out[i] = UInt8(rem[i]) }
+		return out
+	}
+
+	// MARK: - Bitstream / codeword assembly
+
+	static func buildCodewords(_ data: [UInt8], _ version: Int, _ ecc: ECC) -> [UInt8]? {
+		let t = eccTable(version, ecc)
+		let totalBlocks = t.b1 + t.b2
+		if totalBlocks == 0 { return nil }
+		let totalDataCW = t.b1 * t.d1 + t.b2 * t.d2
+		let capacityBits = totalDataCW * 8
+
+		var bits: [Bool] = []
+		bits.reserveCapacity(capacityBits)
+
+		func appendBits(_ value: Int, _ count: Int) {
+			if count <= 0 { return }
+			var k = count - 1
+			while k >= 0 {
+				bits.append(((value >> k) & 1) == 1)
+				k -= 1
+			}
+		}
+
+		// Mode indicator (byte mode = 0100) + character count + payload.
+		appendBits(0b0100, 4)
+		appendBits(data.count, charCountBits(version))
+		for byte in data { appendBits(Int(byte), 8) }
+		if bits.count > capacityBits { return nil }
+
+		// Terminator (up to 4 zero bits).
+		let termLen = capacityBits - bits.count
+		appendBits(0, termLen < 4 ? termLen : 4)
+
+		// Padding bits to extend to a codeword boundary. Matches ISO 18004 /
+		// segno: (8 - length % 8) bits are appended, which adds a full zero byte
+		// when the stream already ends on a byte boundary.
+		appendBits(0, 8 - (bits.count % 8))
+
+		// Pad bytes 0xEC / 0x11 alternating.
+		var pad = 0xEC
+		while bits.count < capacityBits {
+			appendBits(pad, 8)
+			pad = (pad == 0xEC) ? 0x11 : 0xEC
+		}
+
+		// Pack into data codewords.
+		var dataCW = [UInt8](repeating: 0, count: totalDataCW)
+		for i in 0..<totalDataCW {
+			var b = 0
+			for j in 0..<8 {
+				b = (b << 1) | (bits[i * 8 + j] ? 1 : 0)
+			}
+			dataCW[i] = UInt8(b)
+		}
+
+		// Split into blocks and compute EC.
+		let (exp, log) = gfTables()
+		var blocks: [[UInt8]] = []
+		var ecBlocks: [[UInt8]] = []
+		var idx = 0
+		for blk in 0..<totalBlocks {
+			let dcount = blk < t.b1 ? t.d1 : t.d2
+			var blockData = [UInt8](repeating: 0, count: dcount)
+			for j in 0..<dcount {
+				blockData[j] = dataCW[idx + j]
+			}
+			idx += dcount
+			blocks.append(blockData)
+			ecBlocks.append(rsEncode(blockData, t.ec, exp, log))
+		}
+
+		// Interleave data, then EC.
+		var result: [UInt8] = []
+		result.reserveCapacity(totalDataCW + t.ec * totalBlocks)
+		let maxData = t.d1 > t.d2 ? t.d1 : t.d2
+		for i in 0..<maxData {
+			for b in 0..<totalBlocks {
+				if i < blocks[b].count { result.append(blocks[b][i]) }
+			}
+		}
+		for i in 0..<t.ec {
+			for b in 0..<totalBlocks {
+				result.append(ecBlocks[b][i])
+			}
+		}
+		return result
+	}
+
+	// MARK: - Matrix construction
+
+	static func buildMatrix(_ interleaved: [UInt8], _ version: Int, _ ecc: ECC, _ mask: Int, eval: Bool = false) -> [[Bool]] {
+		let n = 17 + 4 * version
+		var modules = [[Bool]](repeating: [Bool](repeating: false, count: n), count: n)
+		var reserved = [[Bool]](repeating: [Bool](repeating: false, count: n), count: n)
+
+		// --- Finder patterns + separators ---
+		func placeFinder(_ r0: Int, _ c0: Int) {
+			for dr in -1...7 {
+				for dc in -1...7 {
+					let r = r0 + dr
+					let c = c0 + dc
+					if r < 0 || r >= n || c < 0 || c >= n { continue }
+					var dark = false
+					if dr >= 0 && dr <= 6 && dc >= 0 && dc <= 6 {
+						let isBorder = dr == 0 || dr == 6 || dc == 0 || dc == 6
+						let isCenter = dr >= 2 && dr <= 4 && dc >= 2 && dc <= 4
+						dark = isBorder || isCenter
+					}
+					modules[r][c] = dark
+					reserved[r][c] = true
+				}
+			}
+		}
+		placeFinder(0, 0)
+		placeFinder(0, n - 7)
+		placeFinder(n - 7, 0)
+
+		// --- Timing patterns ---
+		if n > 16 {
+			for i in 8...(n - 9) {
+				let dark = (i % 2 == 0)
+				if !reserved[6][i] { modules[6][i] = dark; reserved[6][i] = true }
+				if !reserved[i][6] { modules[i][6] = dark; reserved[i][6] = true }
+			}
+		}
+
+		// --- Dark module --- (placed with format info, so absent during evaluation)
+		if !eval { modules[n - 8][8] = true }
+		reserved[n - 8][8] = true
+
+		// --- Alignment patterns ---
+		let positions = alignmentPositions(version)
+		let cnt = positions.count
+		if cnt > 0 {
+			for a in 0..<cnt {
+				for b in 0..<cnt {
+					if (a == 0 && b == 0) || (a == 0 && b == cnt - 1) || (a == cnt - 1 && b == 0) { continue }
+					let cr = positions[a]
+					let cc = positions[b]
+					for dr in -2...2 {
+						for dc in -2...2 {
+							let r = cr + dr
+							let c = cc + dc
+							let cheb = max(dr < 0 ? -dr : dr, dc < 0 ? -dc : dc)
+							modules[r][c] = (cheb != 1)
+							reserved[r][c] = true
+						}
+					}
+				}
+			}
+		}
+
+		// --- Version information (v >= 7) ---
+		if version >= 7 {
+			var rem = version
+			for _ in 0..<12 { rem = (rem << 1) ^ ((rem >> 11) * 0x1F25) }
+			let vbits = (version << 12) | rem
+			for i in 0..<18 {
+				let bit = ((vbits >> i) & 1) == 1
+				let a = n - 11 + i % 3
+				let b = i / 3
+				if !eval { modules[b][a] = bit; modules[a][b] = bit }
+				reserved[b][a] = true
+				reserved[a][b] = true
+			}
+		}
+
+		// --- Reserve format information areas (filled after masking) ---
+		for i in 0...5 { reserved[i][8] = true }
+		reserved[7][8] = true
+		reserved[8][8] = true
+		reserved[8][7] = true
+		for i in 9...14 { reserved[8][14 - i] = true }
+		for i in 0...7 { reserved[8][n - 1 - i] = true }
+		for i in 8...14 { reserved[n - 15 + i][8] = true }
+
+		// --- Place data bits (zigzag, right to left) ---
+		var dataBits: [Bool] = []
+		dataBits.reserveCapacity(interleaved.count * 8)
+		for cw in interleaved {
+			let v = Int(cw)
+			var k = 7
+			while k >= 0 {
+				dataBits.append(((v >> k) & 1) == 1)
+				k -= 1
+			}
+		}
+		let nbits = dataBits.count
+		var bitPos = 0
+		var col = n - 1
+		while col > 0 {
+			if col == 6 { col -= 1 }
+			let upward = (((col + 1) & 2) == 0)
+			var vert = 0
+			while vert < n {
+				for j in 0..<2 {
+					let c = col - j
+					let r = upward ? (n - 1 - vert) : vert
+					if !reserved[r][c] {
+						var dark = false
+						if bitPos < nbits {
+							dark = dataBits[bitPos]
+							bitPos += 1
+						}
+						modules[r][c] = dark
+					}
+				}
+				vert += 1
+			}
+			col -= 2
+		}
+
+		// --- Apply mask to data (non-reserved) modules ---
+		for r in 0..<n {
+			for c in 0..<n {
+				if reserved[r][c] { continue }
+				var flip = false
+				switch mask {
+				case 0: flip = (r + c) % 2 == 0
+				case 1: flip = r % 2 == 0
+				case 2: flip = c % 3 == 0
+				case 3: flip = (r + c) % 3 == 0
+				case 4: flip = (r / 2 + c / 3) % 2 == 0
+				case 5: flip = (r * c) % 2 + (r * c) % 3 == 0
+				case 6: flip = ((r * c) % 2 + (r * c) % 3) % 2 == 0
+				case 7: flip = ((r + c) % 2 + (r * c) % 3) % 2 == 0
+				default: flip = false
+				}
+				if flip { modules[r][c].toggle() }
+			}
+		}
+
+		// --- Format information --- (skipped during evaluation: ISO 18004 7.8.3)
+		if !eval {
+			let eccFmt: Int
+			switch ecc {
+			case .l: eccFmt = 1
+			case .m: eccFmt = 0
+			case .q: eccFmt = 3
+			case .h: eccFmt = 2
+			}
+			let dataF = (eccFmt << 3) | mask
+			var remF = dataF
+			for _ in 0..<10 { remF = (remF << 1) ^ ((remF >> 9) * 0x537) }
+			let fbits = ((dataF << 10) | remF) ^ 0x5412
+			func fbit(_ i: Int) -> Bool { ((fbits >> i) & 1) == 1 }
+
+			for i in 0...5 { modules[i][8] = fbit(i) }
+			modules[7][8] = fbit(6)
+			modules[8][8] = fbit(7)
+			modules[8][7] = fbit(8)
+			for i in 9...14 { modules[8][14 - i] = fbit(i) }
+			for i in 0...7 { modules[8][n - 1 - i] = fbit(i) }
+			for i in 8...14 { modules[n - 15 + i][8] = fbit(i) }
+			modules[n - 8][8] = true
+		}
+
+		return modules
+	}
+
+	// MARK: - Mask penalty scoring (mirrors the ISO 18004 / segno scoring exactly)
+
+	static func penalty(_ m: [[Bool]]) -> Int {
+		let n = m.count
+		let N2 = 3, N4 = 10
+		var scoreN1 = 0
+		var scoreN2 = 0
+		var scoreN3 = 0
+
+		// 1:1:3:1:1 pattern detection (dark light dark dark dark light dark)
+		// preceded or followed by a 4-module light area, or at the edge.
+		let pat: [Bool] = [true, false, true, true, true, false, true]
+		func matchAt(_ seq: [Bool], _ i: Int) -> Bool {
+			for k in 0..<7 { if seq[i + k] != pat[k] { return false } }
+			return true
+		}
+		func findPattern(_ seq: [Bool], _ start: Int) -> Int {
+			var i = start
+			let last = n - 7
+			while i <= last {
+				if matchAt(seq, i) { return i }
+				i += 1
+			}
+			return -1
+		}
+		func allLight(_ seq: [Bool], _ lo: Int, _ hi: Int) -> Bool {
+			var i = lo
+			while i < hi {
+				if seq[i] { return false }
+				i += 1
+			}
+			return true
+		}
+		func n3Count(_ seq: [Bool]) -> Int {
+			var count = 0
+			var idx = findPattern(seq, 0)
+			while idx != -1 {
+				var offset = idx + 7
+				let before = allLight(seq, max(idx - 4, 0), min(idx, n))
+				let after = allLight(seq, max(offset, 0), min(offset + 4, n))
+				if idx == 0 || idx == n - 7 || before || after {
+					count += 40
+				} else {
+					offset = idx + 4
+				}
+				idx = findPattern(seq, offset)
+			}
+			return count
+		}
+
+		var dark = 0
+		var lastRow: [Bool]? = nil
+		for i in 0..<n {
+			let row = m[i]
+			var col = [Bool](repeating: false, count: n)
+			var rowPrev = false
+			var colPrev = false
+			var firstR = true
+			var firstC = true
+			var n1Row = 0
+			var n1Col = 0
+			for j in 0..<n {
+				let rb = row[j]
+				let cb = m[j][i]
+				col[j] = cb
+				if rb { dark += 1 }
+				// N1 row
+				if !firstR && rb == rowPrev {
+					n1Row += 1
+				} else {
+					if n1Row >= 5 { scoreN1 += n1Row - 2 }
+					n1Row = 1
+				}
+				// N1 col
+				if !firstC && cb == colPrev {
+					n1Col += 1
+				} else {
+					if n1Col >= 5 { scoreN1 += n1Col - 2 }
+					n1Col = 1
+				}
+				// N2
+				if let lr = lastRow, j > 0 && rb == rowPrev && rb == lr[j] && rb == lr[j - 1] {
+					scoreN2 += N2
+				}
+				rowPrev = rb; firstR = false
+				colPrev = cb; firstC = false
+			}
+			if n1Row >= 5 { scoreN1 += n1Row - 2 }
+			if n1Col >= 5 { scoreN1 += n1Col - 2 }
+			scoreN3 += n3Count(row)
+			scoreN3 += n3Count(col)
+			lastRow = row
+		}
+
+		// N4: proportion of dark modules.
+		let total = n * n
+		let diff = dark * 100 - 50 * total
+		let scoreN4 = N4 * ((diff < 0 ? -diff : diff) / (5 * total))
+
+		return scoreN1 + scoreN2 + scoreN3 + scoreN4
+	}
+}


### PR DESCRIPTION
Link each Switch profile to its own Discord; presence follows whoever's playing (optional "Default" fallback) instead of one shared account.
- On-device QR code pairing (scan with phone) + URL fallback — no web applet
- Sysmodule: per-account auth/sessions, refresh-token rotation, atomic JSON saves, exports the Switch user list for the config app
- Build: Makefile auto-detects the Swift toolchain and compiles the emitted IR with its own clang